### PR TITLE
feat(app): convert routing and session helpers to TS

### DIFF
--- a/app/app/router.ts
+++ b/app/app/router.ts
@@ -1,15 +1,53 @@
-function decode(value) {
+type ShellMode = "home" | "vault";
+type NavMode = "none" | "core" | "plugin";
+type RouteName =
+    | "home"
+    | "unlock"
+    | "identifiers"
+    | "identifier-detail"
+    | "remotes"
+    | "remote-detail"
+    | "settings"
+    | "kf-witnesses"
+    | "kf-watchers"
+    | "not-found";
+
+interface RouteParams {
+    vaultId?: string;
+    aid?: string;
+}
+
+interface RouteDefinition {
+    name: RouteName;
+    shellMode: ShellMode;
+    navMode: NavMode;
+    requiresVault?: boolean;
+    requiresUnlock?: boolean;
+}
+
+interface MatchRouteDefinition extends RouteDefinition {
+    regex: RegExp;
+}
+
+export interface Route extends RouteDefinition {
+    path: string;
+    params: RouteParams;
+    regex?: RegExp;
+}
+
+function decode(value: string): string {
     return decodeURIComponent(value);
 }
-function safeDecode(value) {
+
+function safeDecode(value: string): string | null {
     try {
         return decode(value);
-    }
-    catch {
+    } catch {
         return null;
     }
 }
-function notFoundRoute(path) {
+
+function notFoundRoute(path: string): Route {
     return {
         name: "not-found",
         path,
@@ -18,16 +56,18 @@ function notFoundRoute(path) {
         params: {},
     };
 }
-export function normalizeHash(hash = window.location.hash) {
+
+export function normalizeHash(hash = window.location.hash): string {
     const withoutHash = hash.startsWith("#") ? hash.slice(1) : hash;
     if (!withoutHash) {
         return "/";
     }
     return withoutHash.startsWith("/") ? withoutHash : `/${withoutHash}`;
 }
-export function parseRoute(hash = window.location.hash) {
+
+export function parseRoute(hash = window.location.hash): Route {
     const path = normalizeHash(hash);
-    const patterns = [
+    const patterns: MatchRouteDefinition[] = [
         {
             name: "home",
             regex: /^\/$/,
@@ -98,12 +138,14 @@ export function parseRoute(hash = window.location.hash) {
             requiresUnlock: true,
         },
     ];
+
     for (const pattern of patterns) {
         const match = path.match(pattern.regex);
         if (!match) {
             continue;
         }
-        const params = {};
+
+        const params: RouteParams = {};
         if (match[1]) {
             const vaultId = safeDecode(match[1]);
             if (vaultId == null) {
@@ -118,41 +160,53 @@ export function parseRoute(hash = window.location.hash) {
             }
             params.aid = aid;
         }
+
         return {
             ...pattern,
             path,
             params,
         };
     }
+
     return notFoundRoute(path);
 }
-export function navigate(href) {
+
+export function navigate(href: string): void {
     window.location.hash = href.startsWith("#") ? href.slice(1) : href;
 }
-export function homeHref() {
+
+export function homeHref(): string {
     return "#/";
 }
-export function unlockHref(vaultId) {
+
+export function unlockHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/unlock`;
 }
-export function identifiersHref(vaultId) {
+
+export function identifiersHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/identifiers`;
 }
-export function identifierDetailHref(vaultId, aid) {
+
+export function identifierDetailHref(vaultId: string, aid: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/identifiers/${encodeURIComponent(aid)}`;
 }
-export function remotesHref(vaultId) {
+
+export function remotesHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/remotes`;
 }
-export function remoteDetailHref(vaultId, aid) {
+
+export function remoteDetailHref(vaultId: string, aid: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/remotes/${encodeURIComponent(aid)}`;
 }
-export function settingsHref(vaultId) {
+
+export function settingsHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/settings`;
 }
-export function kfWitnessesHref(vaultId) {
+
+export function kfWitnessesHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/kf/witnesses`;
 }
-export function kfWatchersHref(vaultId) {
+
+export function kfWatchersHref(vaultId: string): string {
     return `#/vaults/${encodeURIComponent(vaultId)}/kf/watchers`;
 }

--- a/app/app/session.js
+++ b/app/app/session.js
@@ -6,12 +6,10 @@ export function createSessionStore(initialState = {}) {
         lastCoreRoutes: {},
         ...initialState,
     };
-
     return {
         snapshot() {
             return state;
         },
-
         patch(partial) {
             state = {
                 ...state,
@@ -19,7 +17,6 @@ export function createSessionStore(initialState = {}) {
             };
             return state;
         },
-
         rememberCoreRoute(vaultId, href) {
             state = {
                 ...state,

--- a/app/app/session.ts
+++ b/app/app/session.ts
@@ -1,0 +1,48 @@
+export interface SessionState {
+    vaults: unknown[];
+    unlockedVaultId: string | null;
+    mobileNavOpen: boolean;
+    lastCoreRoutes: Record<string, string>;
+    [key: string]: unknown;
+}
+
+export interface SessionStore {
+    snapshot(): SessionState;
+    patch(partial: Partial<SessionState>): SessionState;
+    rememberCoreRoute(vaultId: string, href: string): SessionState;
+}
+
+export function createSessionStore(initialState: Partial<SessionState> = {}): SessionStore {
+    let state: SessionState = {
+        vaults: [],
+        unlockedVaultId: null,
+        mobileNavOpen: false,
+        lastCoreRoutes: {},
+        ...initialState,
+    };
+
+    return {
+        snapshot(): SessionState {
+            return state;
+        },
+
+        patch(partial: Partial<SessionState>): SessionState {
+            state = {
+                ...state,
+                ...partial,
+            };
+            return state;
+        },
+
+        rememberCoreRoute(vaultId: string, href: string): SessionState {
+            state = {
+                ...state,
+                lastCoreRoutes: {
+                    ...state.lastCoreRoutes,
+                    [vaultId]: href,
+                },
+            };
+            return state;
+        },
+    };
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,8 @@
   },
   "include": [
     "app/runtime/messages.ts",
-    "app/runtime/method-catalog.ts"
+    "app/runtime/method-catalog.ts",
+    "app/app/router.ts",
+    "app/app/session.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
   },
   "include": [
     "app/runtime/messages.ts",
-    "app/runtime/method-catalog.ts"
+    "app/runtime/method-catalog.ts",
+    "app/app/router.ts",
+    "app/app/session.ts"
   ],
   "exclude": [
     "vendor",


### PR DESCRIPTION
## Summary
Convert the FortWeb routing and session helpers into emitted TypeScript modules.

## Included
- convert `router.js` to `router.ts`
- convert `session.js` to `session.ts`
- widen the TS config only for this helper slice

## Validation
- `npm run typecheck`
- `npm run build:runtime`
