### PR TITLE
test(web): add browser smoke coverage and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,54 @@ python3 scripts/serve_local.py
 Then use **`http://127.0.0.1:8765/fortweb/app/`** (the script redirects `/` there). Stop with Ctrl+C.
 
 The **SharedArrayBuffer** / PyScript FAQ warning in the console is expected for a plain `http.server`; the app should still load. If wheel fetches fail, confirm nothing else is bound to the same port and that you are not mixing two different server roots in multiple tabs.
+
+## Type checking
+
+FortWeb now has an active TypeScript conversion lane for the runtime seam and the smallest adjacent app helpers.
+
+This does **not** change the browser runtime path, bundling model, or local serve path. The browser still loads `.js` files from `app/`, but the first converted runtime files now use `.ts` as the source of truth and emit `.js` back into the same runtime path.
+
+From the `fortweb` repo:
+
+```bash
+npm run build:runtime
+npm run typecheck
+npm run test:e2e
+```
+
+## Browser smoke tests
+
+FortWeb now has a validation-first browser smoke harness using Playwright.
+
+The smoke suite stays aligned with the current FortWeb runtime posture:
+
+- it serves the app through `python3 scripts/serve_local.py`
+- it keeps the browser entrypoint at `app/index.html`
+- it checks one real app boot path plus deterministic fixture routes
+- it does not introduce a bundler-first test runtime
+
+From the `fortweb` repo:
+
+```bash
+npm run test:e2e
+```
+
+Current smoke coverage:
+
+- app boot through `/fortweb/app/`
+- fixture index route
+- populated identifiers fixture
+- hosted witnesses fixture
+
+The fixture routes remain the most stable UI validation surface because they render deterministic states without depending on live wallet data.
+
+Current scope:
+
+- `app/runtime/messages.ts` -> emits `app/runtime/messages.js`
+- `app/runtime/method-catalog.ts` -> emits `app/runtime/method-catalog.js`
+- `app/runtime/logger.ts` -> emits `app/runtime/logger.js`
+- `app/runtime/bridge.ts` -> emits `app/runtime/bridge.js`
+- `app/app/router.ts` -> emits `app/app/router.js`
+- `app/app/session.ts` -> emits `app/app/session.js`
+
+The current conversion slice stays intentionally narrow so FortWeb can replace JavaScript source files with TypeScript without forcing a bundler-first rewrite across the whole app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,71 @@
     "": {
       "name": "fortweb",
       "devDependencies": {
+        "@playwright/test": "1.58.2",
         "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "type": "module",
   "scripts": {
     "build:runtime": "tsc --project tsconfig.build.json",
-    "typecheck": "tsc --project tsconfig.json"
+    "typecheck": "tsc --project tsconfig.json",
+    "pretest:e2e": "npm run build:runtime",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "devDependencies": {
+    "@playwright/test": "1.58.2",
     "typescript": "5.9.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './playwright',
+    fullyParallel: false,
+    workers: process.env['CI'] ? 1 : undefined,
+    retries: process.env['CI'] ? 1 : 0,
+    reporter: process.env['CI'] ? 'github' : 'list',
+    webServer: {
+        command: 'python3 scripts/serve_local.py --no-open --port 4173',
+        url: 'http://127.0.0.1:4173/fortweb/app/',
+        reuseExistingServer: !process.env['CI'],
+        timeout: 60_000,
+    },
+    use: {
+        baseURL: 'http://127.0.0.1:4173',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+});

--- a/playwright/fortweb-smoke.spec.ts
+++ b/playwright/fortweb-smoke.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from '@playwright/test';
+
+function isKnownRuntimeNoise(text: string): boolean {
+    return (
+        text.includes('SyntaxWarning: invalid escape sequence') ||
+        text.includes('/lib/python3.13/site-packages/') ||
+        text.includes("b'(?P<kind2>") ||
+        text.includes('MapDom is a subclass of IceMapDom') ||
+        text.includes('RawDom is subclass of MapDom')
+    );
+}
+
+function collectUnexpectedPageErrors(page: Page): string[] {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+    });
+    return pageErrors;
+}
+
+function collectUnexpectedConsoleErrors(page: Page): string[] {
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+        if (message.type() !== 'error') {
+            return;
+        }
+
+        const text = message.text();
+        if (text.includes('favicon.ico')) {
+            return;
+        }
+        if (isKnownRuntimeNoise(text)) {
+            return;
+        }
+
+        consoleErrors.push(text);
+    });
+    return consoleErrors;
+}
+
+async function expectNoUnexpectedErrors(page: Page, pageErrors: string[], consoleErrors: string[]): Promise<void> {
+    await page.waitForTimeout(250);
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+}
+
+test.describe('FortWeb smoke', () => {
+    test('app boot renders the vault landing page', async ({ page }) => {
+        const pageErrors = collectUnexpectedPageErrors(page);
+        const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+        await page.goto('/fortweb/app/');
+
+        await expect(page.locator('#app-root')).toBeAttached();
+        await expect(page.getByRole('heading', { name: 'Your Vaults' })).toBeVisible();
+        await expect(page).toHaveTitle(/Vaults \| Fort/);
+
+        await expectNoUnexpectedErrors(page, pageErrors, consoleErrors);
+    });
+
+    test('fixture index route lists deterministic fixture pages', async ({ page }) => {
+        const pageErrors = collectUnexpectedPageErrors(page);
+        const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+        await page.goto('/fortweb/app/#/_fixtures');
+
+        await expect(page.getByRole('heading', { name: 'Fixture Routes' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'vaults/populated' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'watchers/populated' })).toBeVisible();
+
+        await expectNoUnexpectedErrors(page, pageErrors, consoleErrors);
+    });
+
+    test('identifiers fixture renders populated table state', async ({ page }) => {
+        const pageErrors = collectUnexpectedPageErrors(page);
+        const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+        await page.goto('/fortweb/app/#/_fixtures/identifiers/populated');
+
+        await expect(page).toHaveTitle(/Identifiers \| Fort/);
+        await expect(page.getByText('Local Identifiers')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'primary-aid' })).toBeVisible();
+
+        await expectNoUnexpectedErrors(page, pageErrors, consoleErrors);
+    });
+
+    test('witness fixture renders hosted witness account state', async ({ page }) => {
+        const pageErrors = collectUnexpectedPageErrors(page);
+        const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+        await page.goto('/fortweb/app/#/_fixtures/witnesses/account');
+
+        await expect(page).toHaveTitle(/KERI Foundation Witnesses \| Fort/);
+        await expect(page.getByText('Hosted Witnesses')).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'KF Witness wan-0' })).toBeVisible();
+
+        await expectNoUnexpectedErrors(page, pageErrors, consoleErrors);
+    });
+});


### PR DESCRIPTION
## Summary
Add browser smoke coverage and documentation for the FortWeb TypeScript migration lane.

## Included
- add Playwright smoke coverage on the existing `serve_local.py` path
- document build, typecheck, and smoke-test workflow in the README
- keep fixture routes as the stable browser validation surface

## Validation
- `npm run typecheck`
- `npm run test:e2e`
