### PR TITLE
feat(runtime): convert native logger bridge to TS

### DIFF
--- a/app/runtime/logger.ts
+++ b/app/runtime/logger.ts
@@ -1,73 +1,103 @@
 const NATIVE_BRIDGE_HANDLER_NAME = "bridge";
-function createNativeBridgeAdapter() {
+
+interface NativeBridgePayload {
+    type: string;
+    timestamp: string;
+    message: string;
+}
+
+interface NativeBridgeAdapter {
+    postMessage(payload: NativeBridgePayload): void;
+}
+
+function createNativeBridgeAdapter(): NativeBridgeAdapter {
     if (typeof window !== "undefined") {
         const webkitBridge = window.webkit?.messageHandlers?.[NATIVE_BRIDGE_HANDLER_NAME];
         if (webkitBridge && typeof webkitBridge.postMessage === "function") {
             return {
-                postMessage(payload) {
+                postMessage(payload: NativeBridgePayload): void {
                     webkitBridge.postMessage(payload);
                 },
             };
         }
+
         const androidBridge = window.bridge;
         if (androidBridge && typeof androidBridge.postMessage === "function") {
             return {
-                postMessage(payload) {
+                postMessage(payload: NativeBridgePayload): void {
                     androidBridge.postMessage(JSON.stringify(payload));
                 },
             };
         }
     }
+
     return {
-        postMessage() { },
+        postMessage(): void {},
     };
 }
+
 const nativeBridge = createNativeBridgeAdapter();
-function isoNow() {
+
+function isoNow(): string {
     return new Date().toISOString();
 }
-function formatDiagnosticValue(value) {
+
+function formatDiagnosticValue(value: unknown): string {
     if (typeof value === "string") {
         return JSON.stringify(value);
     }
     return String(value);
 }
-export function formatDiagnosticMessage(event, fields = {}) {
+
+export function formatDiagnosticMessage(
+    event: string,
+    fields: Record<string, unknown> = {},
+): string {
     const parts = Object.entries(fields)
         .filter(([, value]) => value !== undefined && value !== null && value !== "")
         .map(([key, value]) => `${key}=${formatDiagnosticValue(value)}`);
+
     if (parts.length === 0) {
         return `[fortweb.runtime] event=${event}`;
     }
+
     return `[fortweb.runtime] event=${event} ${parts.join(" ")}`;
 }
-export function postToNativeBridge(payload) {
+
+export function postToNativeBridge(payload: NativeBridgePayload): void {
     try {
         nativeBridge.postMessage(payload);
-    }
-    catch { }
+    } catch {}
 }
-export function postLog(event, fields = {}) {
+
+export function postLog(event: string, fields: Record<string, unknown> = {}): void {
     postToNativeBridge({
         type: "log",
         timestamp: isoNow(),
         message: formatDiagnosticMessage(event, fields),
     });
 }
-export function postLifecycle(state, fields = {}) {
+
+export function postLifecycle(state: string, fields: Record<string, unknown> = {}): void {
     postToNativeBridge({
         type: "lifecycle",
         timestamp: isoNow(),
         message: formatDiagnosticMessage("worker_lifecycle", { state, ...fields }),
     });
 }
-export function postError(errorType, message, fields = {}) {
+
+export function postError(
+    errorType: "js_error" | "unhandled_rejection",
+    message: string,
+    fields: Record<string, unknown> = {},
+): void {
     const fieldSuffix = Object.keys(fields).length > 0
         ? " " + Object.entries(fields)
             .filter(([, value]) => value !== undefined && value !== null && value !== "")
             .map(([key, value]) => `${key}=${formatDiagnosticValue(value)}`)
             .join(" ")
         : "";
+
     postToNativeBridge({
         type: errorType,
         timestamp: isoNow(),

--- a/app/runtime/types/browser-bridge.d.ts
+++ b/app/runtime/types/browser-bridge.d.ts
@@ -1,0 +1,14 @@
+interface NativeBridgeMessageHandler {
+    postMessage(payload: unknown): void;
+}
+
+interface AndroidBridgeHandler {
+    postMessage(payload: string): void;
+}
+
+interface Window {
+    webkit?: {
+        messageHandlers?: Record<string, NativeBridgeMessageHandler | undefined>;
+    };
+    bridge?: AndroidBridgeHandler;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,6 +9,8 @@
     "app/runtime/messages.ts",
     "app/runtime/method-catalog.ts",
     "app/app/router.ts",
-    "app/app/session.ts"
+    "app/app/session.ts",
+    "app/runtime/logger.ts",
+    "app/runtime/types/**/*.d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "app/runtime/messages.ts",
     "app/runtime/method-catalog.ts",
     "app/app/router.ts",
-    "app/app/session.ts"
+    "app/app/session.ts",
+    "app/runtime/logger.ts",
+    "app/runtime/types/**/*.d.ts"
   ],
   "exclude": [
     "vendor",


### PR DESCRIPTION
## Summary
Convert the FortWeb native logger bridge to emitted TypeScript.

## Included
- convert the native logger adapter to `logger.ts`
- add ambient browser bridge typing for the logger path
- keep the logger-specific TS config expansion isolated here

## Validation
- `npm run typecheck`
- `npm run build:runtime`
