### PR TITLE
feat(runtime): convert worker bridge to TS

### DIFF
--- a/app/runtime/bridge.ts
+++ b/app/runtime/bridge.ts
@@ -1,50 +1,86 @@
-import { PyWorker } from "../../vendor/pyscript/2025.11.2/core.js";
+import { PyWorker, type PyWorkerHandle } from "../../vendor/pyscript/2025.11.2/core.js";
 import { parse as parseToml } from "../../vendor/pyscript/2025.11.2/toml-BK2RWy-G.js";
-import { createRuntimeRequest, isRuntimeResponse } from "./messages.js";
+import { createRuntimeRequest, isRuntimeResponse, type RuntimeResponse } from "./messages.js";
 import { postLog, postLifecycle } from "./logger.js";
+
 const WORKER_DIAGNOSTIC_KIND = "fortweb.runtime.diagnostic";
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const WORKER_LIVENESS_TIMEOUT_MS = 3_000;
 const BACKGROUND_STALE_THRESHOLD_MS = 30_000;
 const PRELOAD_MAX_MS = 300_000;
-const METHOD_TIMEOUT_MS = {
+const METHOD_TIMEOUT_MS: Record<string, number> = {
     "vaults.create": 120_000,
     "vaults.open": 90_000,
     "identifiers.create": 90_000,
     "remotes.resolveOobi": 60_000,
     "kf.onboarding.start": 120_000,
 };
-function createRuntimeBridgeError(message, code, cause) {
-    const error = new Error(message);
+
+type RuntimeBridgeError = Error & { code?: string; cause?: unknown };
+
+interface PreloadGate {
+    promise: Promise<string | undefined>;
+    resolve: (reason?: string) => void;
+}
+
+interface WorkerDiagnostic {
+    event: string;
+    level?: string;
+    fields: Record<string, unknown>;
+}
+
+interface RuntimeBridgeOptions {
+    workerUrl: URL;
+    configUrl: URL;
+}
+
+interface RuntimeBridge {
+    request<T extends Record<string, unknown> = Record<string, unknown>>(
+        method: string,
+        params?: Record<string, unknown>,
+        timeoutMs?: number,
+    ): Promise<T>;
+    rawRequest(rawPayload: string, timeoutMs?: number, label?: string): Promise<unknown>;
+    destroy(): void;
+}
+
+function createRuntimeBridgeError(message: string, code: string, cause?: unknown): RuntimeBridgeError {
+    const error = new Error(message) as RuntimeBridgeError;
     error.code = code;
     if (cause !== undefined) {
         error.cause = cause;
     }
     return error;
 }
-function getErrorMessage(error) {
+
+function getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
-function getErrorCode(error, fallback) {
+
+function getErrorCode(error: unknown, fallback: string): string {
     if (error && typeof error === "object" && "code" in error && typeof error.code === "string") {
         return error.code;
     }
     return fallback;
 }
-function roundDurationMs(startedAt) {
+
+function roundDurationMs(startedAt: number): number {
     return Math.max(0, Math.round(performance.now() - startedAt));
 }
-function resolveTimeoutMs(method, timeoutMs) {
+
+function resolveTimeoutMs(method: string, timeoutMs?: number): number {
     if (Number.isFinite(timeoutMs) && (timeoutMs ?? 0) > 0) {
-        return timeoutMs;
+        return timeoutMs as number;
     }
+
     return METHOD_TIMEOUT_MS[method] ?? DEFAULT_REQUEST_TIMEOUT_MS;
 }
-function createPreloadGate() {
+
+function createPreloadGate(): PreloadGate {
     let settled = false;
-    let resolveGate = () => { };
-    const promise = new Promise((resolve) => {
-        resolveGate = (reason) => {
+    let resolveGate: (reason?: string) => void = () => {};
+    const promise = new Promise<string | undefined>((resolve) => {
+        resolveGate = (reason?: string) => {
             if (settled) {
                 return;
             }
@@ -54,52 +90,68 @@ function createPreloadGate() {
     });
     return { promise, resolve: resolveGate };
 }
-function withTimeout(promise, timeoutMs, method) {
+
+function withTimeout<T>(promise: Promise<T> | T, timeoutMs: number, method: string): Promise<T> {
     return new Promise((resolve, reject) => {
         const timeoutId = window.setTimeout(() => {
             reject(createRuntimeBridgeError(`Runtime request timed out for ${method}.`, "TIMEOUT"));
         }, timeoutMs);
-        Promise.resolve(promise).then((value) => {
-            clearTimeout(timeoutId);
-            resolve(value);
-        }, (error) => {
-            clearTimeout(timeoutId);
-            reject(error);
-        });
+
+        Promise.resolve(promise).then(
+            (value) => {
+                clearTimeout(timeoutId);
+                resolve(value);
+            },
+            (error) => {
+                clearTimeout(timeoutId);
+                reject(error);
+            },
+        );
     });
 }
-function parseRuntimeResponse(rawResponse) {
-    const payload = typeof rawResponse === "string"
-        ? rawResponse
-        : rawResponse?.data ?? rawResponse;
+
+function parseRuntimeResponse(rawResponse: unknown): unknown {
+    const payload =
+        typeof rawResponse === "string"
+            ? rawResponse
+            : (rawResponse as { data?: unknown } | null | undefined)?.data ?? rawResponse;
+
     if (typeof payload !== "string") {
         return payload;
     }
+
     try {
-        return JSON.parse(payload);
-    }
-    catch (error) {
-        throw createRuntimeBridgeError("Runtime worker returned a malformed response.", "BAD_RESPONSE", error);
+        return JSON.parse(payload) as unknown;
+    } catch (error) {
+        throw createRuntimeBridgeError(
+            "Runtime worker returned a malformed response.",
+            "BAD_RESPONSE",
+            error,
+        );
     }
 }
-function parseWorkerDiagnostic(rawPayload) {
-    const payload = typeof rawPayload === "string"
-        ? (() => {
-            try {
-                return JSON.parse(rawPayload);
-            }
-            catch {
-                return null;
-            }
-        })()
-        : rawPayload?.data ?? rawPayload;
+
+function parseWorkerDiagnostic(rawPayload: unknown): WorkerDiagnostic | null {
+    const payload =
+        typeof rawPayload === "string"
+            ? (() => {
+                  try {
+                      return JSON.parse(rawPayload) as unknown;
+                  } catch {
+                      return null;
+                  }
+              })()
+            : (rawPayload as { data?: unknown } | null | undefined)?.data ?? rawPayload;
+
     if (!payload || typeof payload !== "object") {
         return null;
     }
-    const candidate = payload;
+
+    const candidate = payload as Record<string, unknown>;
     if (candidate.kind !== WORKER_DIAGNOSTIC_KIND || typeof candidate.event !== "string") {
         return null;
     }
+
     const { kind: _kind, event, level, ...fields } = candidate;
     return {
         event,
@@ -107,38 +159,45 @@ function parseWorkerDiagnostic(rawPayload) {
         fields,
     };
 }
-export function createRuntimeBridge({ workerUrl, configUrl }) {
+
+export function createRuntimeBridge({ workerUrl, configUrl }: RuntimeBridgeOptions): RuntimeBridge {
     let requestCounter = 0;
-    let bootedWorker = null;
-    let workerPromise = null;
+    let bootedWorker: PyWorkerHandle | null = null;
+    let workerPromise: Promise<PyWorkerHandle> | null = null;
     let hiddenSince = 0;
     let preloadGate = createPreloadGate();
-    function resetPreloadGate() {
+
+    function resetPreloadGate(): void {
         preloadGate = createPreloadGate();
     }
-    function resolvePreloadGate(reason = "resolved") {
+
+    function resolvePreloadGate(reason = "resolved"): void {
         preloadGate.resolve(reason);
     }
-    async function waitForPreloadReady() {
+
+    async function waitForPreloadReady(): Promise<void> {
         await Promise.race([
             preloadGate.promise,
-            new Promise((_, reject) => {
+            new Promise<never>((_, reject) => {
                 window.setTimeout(() => {
                     reject(createRuntimeBridgeError("Worker preload timed out.", "TIMEOUT"));
                 }, PRELOAD_MAX_MS);
             }),
         ]);
     }
-    function createWorkerPromise() {
+
+    function createWorkerPromise(): Promise<PyWorkerHandle> {
         resetPreloadGate();
         return (async () => {
             console.time("[bridge] worker boot");
             postLifecycle("boot");
+
             try {
                 const response = await fetch(configUrl.toString());
                 if (!response.ok) {
                     throw new Error(`Unable to load runtime config from ${configUrl.toString()}.`);
                 }
+
                 const config = parseToml(await response.text());
                 const worker = await PyWorker(workerUrl.toString(), {
                     type: "pyodide",
@@ -147,49 +206,55 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                 });
                 postLifecycle("ready");
                 return worker;
-            }
-            catch (error) {
+            } catch (error) {
                 postLifecycle("error", {
                     reason: getErrorMessage(error),
                 });
                 resolvePreloadGate("js_boot_error");
                 throw error;
-            }
-            finally {
+            } finally {
                 console.timeEnd("[bridge] worker boot");
             }
         })();
     }
+
     workerPromise = createWorkerPromise();
-    function invalidateWorker(reason, fields = {}) {
+
+    function invalidateWorker(reason: string, fields: Record<string, unknown> = {}): void {
         postLog("worker_invalidation", {
             level: "warning",
             reason,
             ...fields,
         });
+
         if (bootedWorker) {
             console.warn(`[bridge] invalidating worker: ${reason}`);
             bootedWorker = null;
         }
     }
-    function attachWorkerHandlers(worker) {
+
+    function attachWorkerHandlers(worker: PyWorkerHandle): void {
         if (typeof worker.addEventListener === "function") {
             worker.addEventListener("message", (event) => {
                 const diagnostic = parseWorkerDiagnostic(event?.data);
                 if (!diagnostic) {
                     return;
                 }
+
                 postLog(diagnostic.event, {
                     level: diagnostic.level ?? "info",
                     ...diagnostic.fields,
                 });
-                if (diagnostic.event === "worker_preload_complete" ||
-                    diagnostic.event === "worker_preload_failed") {
+                if (
+                    diagnostic.event === "worker_preload_complete" ||
+                    diagnostic.event === "worker_preload_failed"
+                ) {
                     resolvePreloadGate(diagnostic.event);
                 }
             });
         }
-        worker.onerror = (event) => {
+
+        worker.onerror = (event: { message?: string } | unknown) => {
             console.error("[bridge] worker error:", event && typeof event === "object" && "message" in event ? event.message : event);
             postLifecycle("error", {
                 reason: event && typeof event === "object" && "message" in event && typeof event.message === "string"
@@ -208,31 +273,35 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
             invalidateWorker("message error event");
         };
     }
-    workerPromise.then(attachWorkerHandlers, () => { });
-    async function bootFreshWorker(timeoutMs) {
+
+    workerPromise.then(attachWorkerHandlers, () => {});
+
+    async function bootFreshWorker(timeoutMs: number): Promise<PyWorkerHandle> {
         workerPromise = createWorkerPromise();
-        workerPromise.then(attachWorkerHandlers, () => { });
+        workerPromise.then(attachWorkerHandlers, () => {});
         bootedWorker = await withTimeout(workerPromise, timeoutMs, "worker boot");
         return bootedWorker;
     }
-    async function getWorker(timeoutMs) {
+
+    async function getWorker(timeoutMs: number): Promise<PyWorkerHandle> {
         if (!bootedWorker) {
             try {
                 if (!workerPromise) {
                     workerPromise = createWorkerPromise();
-                    workerPromise.then(attachWorkerHandlers, () => { });
+                    workerPromise.then(attachWorkerHandlers, () => {});
                 }
                 bootedWorker = await withTimeout(workerPromise, timeoutMs, "worker boot");
-            }
-            catch (error) {
+            } catch (error) {
                 console.warn("[bridge] initial worker promise failed, booting fresh worker:", getErrorMessage(error));
                 bootedWorker = await bootFreshWorker(timeoutMs);
             }
         }
+
         await waitForPreloadReady();
         return bootedWorker;
     }
-    async function checkWorkerLiveness(worker) {
+
+    async function checkWorkerLiveness(worker: PyWorkerHandle): Promise<boolean> {
         const pingId = `ping-${Date.now()}`;
         const pingPayload = JSON.stringify({
             id: pingId,
@@ -245,17 +314,16 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
             await withTimeout(worker.sync.handle_request(pingPayload), WORKER_LIVENESS_TIMEOUT_MS, "liveness check");
             console.timeEnd("[bridge] liveness check");
             return true;
-        }
-        catch {
+        } catch {
             console.timeEnd("[bridge] liveness check");
             return false;
         }
     }
-    function onVisibilityChange() {
+
+    function onVisibilityChange(): void {
         if (document.hidden) {
             hiddenSince = Date.now();
-        }
-        else if (hiddenSince > 0) {
+        } else if (hiddenSince > 0) {
             const elapsed = Date.now() - hiddenSince;
             hiddenSince = 0;
             if (elapsed >= BACKGROUND_STALE_THRESHOLD_MS) {
@@ -263,31 +331,41 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
             }
         }
     }
+
     document.addEventListener("visibilitychange", onVisibilityChange);
-    async function rawRequest(rawPayload, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, label = "raw runtime request") {
+
+    async function rawRequest(rawPayload: string, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, label = "raw runtime request"): Promise<unknown> {
         if (typeof rawPayload !== "string") {
             throw new Error("Runtime raw request payload must be a string.");
         }
+
         const worker = await getWorker(timeoutMs);
         console.time(`[bridge] ${label}`);
         const rawResponse = await withTimeout(worker.sync.handle_request(rawPayload), timeoutMs, label);
         console.timeEnd(`[bridge] ${label}`);
         return parseRuntimeResponse(rawResponse);
     }
-    async function request(method, params = {}, timeoutMs) {
+
+    async function request<T extends Record<string, unknown> = Record<string, unknown>>(
+        method: string,
+        params: Record<string, unknown> = {},
+        timeoutMs?: number,
+    ): Promise<T> {
         const effectiveTimeoutMs = resolveTimeoutMs(method, timeoutMs);
         const id = `runtime-${Date.now()}-${requestCounter++}`;
         const payload = JSON.stringify(createRuntimeRequest(id, method, params));
         const startedAt = performance.now();
+
         postLog("request_start", {
             level: "info",
             method,
             request_id: id,
             timeout_ms: effectiveTimeoutMs,
         });
+
         try {
             const response = await rawRequest(payload, effectiveTimeoutMs, method);
-            const result = handleResponse(response, id);
+            const result = handleResponse(response, id) as T;
             postLog("request_end", {
                 level: "info",
                 method,
@@ -296,8 +374,7 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                 duration_ms: roundDurationMs(startedAt),
             });
             return result;
-        }
-        catch (firstError) {
+        } catch (firstError) {
             if (getErrorCode(firstError, "RUNTIME_ERROR") !== "TIMEOUT") {
                 postLog("terminal_failure", {
                     level: "error",
@@ -309,6 +386,7 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                 });
                 throw firstError;
             }
+
             console.warn(`[bridge] ${method} timed out, checking worker liveness`);
             postLog("request_timeout", {
                 level: "warning",
@@ -318,6 +396,7 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
             });
             const worker = await getWorker(effectiveTimeoutMs);
             const alive = await checkWorkerLiveness(worker);
+
             if (alive) {
                 postLog("terminal_failure", {
                     level: "error",
@@ -329,12 +408,14 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                 });
                 throw firstError;
             }
+
             console.warn(`[bridge] worker is dead after timeout, booting fresh worker and retrying ${method}`);
             invalidateWorker("dead after timeout", {
                 request_id: id,
                 method,
             });
             await bootFreshWorker(effectiveTimeoutMs);
+
             const retryId = `runtime-${Date.now()}-${requestCounter++}`;
             const retryPayload = JSON.stringify(createRuntimeRequest(retryId, method, params));
             postLog("request_retry", {
@@ -344,9 +425,10 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                 retry_request_id: retryId,
                 reason: "dead_after_timeout",
             });
+
             try {
                 const retryResponse = await rawRequest(retryPayload, effectiveTimeoutMs, method);
-                const retryResult = handleResponse(retryResponse, retryId);
+                const retryResult = handleResponse(retryResponse, retryId) as T;
                 postLog("request_end", {
                     level: "info",
                     method,
@@ -356,8 +438,7 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
                     duration_ms: roundDurationMs(startedAt),
                 });
                 return retryResult;
-            }
-            catch (retryError) {
+            } catch (retryError) {
                 postLog("terminal_failure", {
                     level: "error",
                     method,
@@ -371,20 +452,30 @@ export function createRuntimeBridge({ workerUrl, configUrl }) {
             }
         }
     }
-    function handleResponse(response, expectedId) {
+
+    function handleResponse(response: unknown, expectedId: string): Record<string, unknown> {
         if (!isRuntimeResponse(response) || response.id !== expectedId) {
-            throw createRuntimeBridgeError("Runtime worker returned an invalid response.", "BAD_RESPONSE");
+            throw createRuntimeBridgeError(
+                "Runtime worker returned an invalid response.",
+                "BAD_RESPONSE",
+            );
         }
+
         if (response.ok) {
             return response.result;
         }
+
         const runtimeError = "error" in response ? response.error : undefined;
-        throw createRuntimeBridgeError(runtimeError?.message || "Runtime request failed.", runtimeError?.code || "RUNTIME_ERROR");
+        throw createRuntimeBridgeError(
+            runtimeError?.message || "Runtime request failed.",
+            runtimeError?.code || "RUNTIME_ERROR",
+        );
     }
+
     return {
         request,
         rawRequest,
-        destroy() {
+        destroy(): void {
             document.removeEventListener("visibilitychange", onVisibilityChange);
             void workerPromise?.then((worker) => {
                 worker.terminate?.();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,9 @@
     "app/app/router.ts",
     "app/app/session.ts",
     "app/runtime/logger.ts",
-    "app/runtime/types/**/*.d.ts"
+    "app/runtime/types/**/*.d.ts",
+    "app/runtime/bridge.ts",
+    "vendor/pyscript/2025.11.2/core.d.ts",
+    "vendor/pyscript/2025.11.2/toml-BK2RWy-G.d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,10 @@
     "app/app/router.ts",
     "app/app/session.ts",
     "app/runtime/logger.ts",
-    "app/runtime/types/**/*.d.ts"
+    "app/runtime/types/**/*.d.ts",
+    "app/runtime/bridge.ts",
+    "vendor/pyscript/2025.11.2/core.d.ts",
+    "vendor/pyscript/2025.11.2/toml-BK2RWy-G.d.ts"
   ],
   "exclude": [
     "vendor",

--- a/vendor/pyscript/2025.11.2/core.d.ts
+++ b/vendor/pyscript/2025.11.2/core.d.ts
@@ -1,0 +1,21 @@
+export interface PyWorkerHandle {
+    sync: {
+        handle_request(payload: string): Promise<unknown> | unknown;
+    };
+    addEventListener?(
+        type: "message",
+        listener: (event: { data?: unknown }) => void,
+    ): void;
+    onerror: ((event: { message?: string } | unknown) => void) | null;
+    onmessageerror: (() => void) | null;
+    terminate?(): void;
+}
+
+export function PyWorker(
+    url: string,
+    options: {
+        type: string;
+        configURL: string;
+        config: unknown;
+    },
+): Promise<PyWorkerHandle>;

--- a/vendor/pyscript/2025.11.2/toml-BK2RWy-G.d.ts
+++ b/vendor/pyscript/2025.11.2/toml-BK2RWy-G.d.ts
@@ -1,0 +1,1 @@
+export function parse(input: string): unknown;


### PR DESCRIPTION
## Summary
Convert the FortWeb runtime worker bridge to emitted TypeScript.

## Included
- convert `bridge.js` to `bridge.ts`
- add the vendored declaration shims required by the bridge import path
- keep the bridge-specific TS config expansion isolated here

## Validation
- `npm run typecheck`
- `npm run build:runtime`
