### PR TITLE
feat(app): extract route data loader

### DIFF
--- a/app/app/main.js
+++ b/app/app/main.js
@@ -7,6 +7,7 @@ import {
     parseRoute,
     unlockHref,
 } from "./router.js";
+import { loadRouteData } from "./page-loader.js";
 import { createSessionStore } from "./session.js";
 import { renderShell } from "./shell.js";
 import {
@@ -422,13 +423,14 @@ async function loadPage(route) {
         };
     }
 
+    const pageData = await loadRouteData({ route, bridge });
+
     if (route.name === "identifiers") {
         const vaultId = route.params.vaultId;
-        const { identifiers } = await bridge.request(METHODS.identifiersList, { vaultId });
         return {
             page: renderIdentifiersPage({
                 vault: findVault(vaultId),
-                identifiers,
+                identifiers: pageData.identifiers || [],
                 onCreateIdentifier: actions.createIdentifier,
             }),
             vault: findVault(vaultId),
@@ -436,14 +438,10 @@ async function loadPage(route) {
     }
 
     if (route.name === "identifier-detail") {
-        const { identifier } = await bridge.request(METHODS.identifiersGet, {
-            vaultId: route.params.vaultId,
-            aid: route.params.aid,
-        });
         return {
             page: renderIdentifierDetailPage({
                 vault: findVault(route.params.vaultId),
-                identifier,
+                identifier: pageData.identifier,
             }),
             vault: findVault(route.params.vaultId),
         };
@@ -451,11 +449,10 @@ async function loadPage(route) {
 
     if (route.name === "remotes") {
         const vaultId = route.params.vaultId;
-        const { remotes } = await bridge.request(METHODS.remotesList, { vaultId });
         return {
             page: renderRemotesPage({
                 vault: findVault(vaultId),
-                remotes,
+                remotes: pageData.remotes || [],
                 filter: currentState().remoteFilter,
                 onResolveRemote: actions.resolveRemoteOobi,
                 onUpdateRemote: actions.updateRemote,
@@ -466,27 +463,20 @@ async function loadPage(route) {
     }
 
     if (route.name === "remote-detail") {
-        const { remote } = await bridge.request(METHODS.remotesGet, {
-            vaultId: route.params.vaultId,
-            aid: route.params.aid,
-        });
         return {
             page: renderRemoteDetailPage({
                 vault: findVault(route.params.vaultId),
-                remote,
+                remote: pageData.remote,
             }),
             vault: findVault(route.params.vaultId),
         };
     }
 
     if (route.name === "settings") {
-        const { settings } = await bridge.request(METHODS.settingsGet, {
-            vaultId: route.params.vaultId,
-        });
         return {
             page: renderSettingsPage({
                 vault: findVault(route.params.vaultId),
-                settings,
+                settings: pageData.settings,
             }),
             vault: findVault(route.params.vaultId),
         };
@@ -494,22 +484,12 @@ async function loadPage(route) {
 
     if (route.name === "kf-witnesses") {
         const vaultId = route.params.vaultId;
-        const bootstrapState = await bridge.request(METHODS.kfBootstrapGet, { vaultId });
-        let witnesses = [];
-        let witnessError = "";
-        if (bootstrapState.account?.status === "onboarded") {
-            try {
-                ({ witnesses } = await bridge.request(METHODS.kfAccountWitnessesList, { vaultId }));
-            } catch (error) {
-                witnessError = error.message || "Failed to load hosted witness rows.";
-            }
-        }
         return {
             page: renderWitnessOverviewPage({
                 vault: findVault(vaultId),
-                bootstrapState,
-                witnesses,
-                witnessError,
+                bootstrapState: pageData.bootstrapState,
+                witnesses: pageData.witnesses || [],
+                witnessError: pageData.witnessError || "",
                 onLoadBootstrap: actions.loadKfBootstrap,
                 onStartOnboarding: actions.startKfOnboarding,
             }),
@@ -519,22 +499,13 @@ async function loadPage(route) {
 
     if (route.name === "kf-watchers") {
         const vaultId = route.params.vaultId;
-        const bootstrapState = await bridge.request(METHODS.kfBootstrapGet, { vaultId });
-        let watchers = [];
-        let watcherError = "";
-        if (bootstrapState.account?.status === "onboarded") {
-            try {
-                ({ watchers } = await bridge.request(METHODS.kfAccountWatchersList, { vaultId }));
-            } catch (error) {
-                watcherError = error.message || "Failed to load hosted watcher rows.";
-            }
-        }
+        const watchers = pageData.watchers || [];
         return {
             page: renderWatcherOverviewPage({
                 vault: findVault(vaultId),
-                bootstrapState,
+                bootstrapState: pageData.bootstrapState,
                 watchers,
-                watcherError,
+                watcherError: pageData.watcherError || "",
                 onRefreshStatuses() {
                     return actions.refreshKfWatcherStatuses(watchers.map((watcher) => watcher.eid));
                 },

--- a/app/app/page-loader.js
+++ b/app/app/page-loader.js
@@ -1,0 +1,69 @@
+import { METHODS } from "../runtime/method-catalog.js";
+export async function loadRouteData({ bridge, route }) {
+    if (route.name === "identifiers") {
+        const vaultId = route.params.vaultId ?? "";
+        return bridge.request(METHODS.identifiersList, { vaultId });
+    }
+    if (route.name === "identifier-detail") {
+        return bridge.request(METHODS.identifiersGet, {
+            vaultId: route.params.vaultId,
+            aid: route.params.aid,
+        });
+    }
+    if (route.name === "remotes") {
+        const vaultId = route.params.vaultId ?? "";
+        return bridge.request(METHODS.remotesList, {
+            vaultId,
+        });
+    }
+    if (route.name === "remote-detail") {
+        return bridge.request(METHODS.remotesGet, {
+            vaultId: route.params.vaultId,
+            aid: route.params.aid,
+        });
+    }
+    if (route.name === "settings") {
+        return bridge.request(METHODS.settingsGet, {
+            vaultId: route.params.vaultId,
+        });
+    }
+    if (route.name === "kf-witnesses") {
+        const vaultId = route.params.vaultId ?? "";
+        const bootstrapState = await bridge.request(METHODS.kfBootstrapGet, { vaultId });
+        let witnesses = [];
+        let witnessError = "";
+        if (bootstrapState.account?.status === "onboarded") {
+            try {
+                ({ witnesses } = await bridge.request(METHODS.kfAccountWitnessesList, { vaultId }));
+            }
+            catch (error) {
+                witnessError = error instanceof Error ? error.message : "Failed to load hosted witness rows.";
+            }
+        }
+        return {
+            bootstrapState,
+            witnesses,
+            witnessError,
+        };
+    }
+    if (route.name === "kf-watchers") {
+        const vaultId = route.params.vaultId ?? "";
+        const bootstrapState = await bridge.request(METHODS.kfBootstrapGet, { vaultId });
+        let watchers = [];
+        let watcherError = "";
+        if (bootstrapState.account?.status === "onboarded") {
+            try {
+                ({ watchers } = await bridge.request(METHODS.kfAccountWatchersList, { vaultId }));
+            }
+            catch (error) {
+                watcherError = error instanceof Error ? error.message : "Failed to load hosted watcher rows.";
+            }
+        }
+        return {
+            bootstrapState,
+            watchers,
+            watcherError,
+        };
+    }
+    return {};
+}

--- a/app/app/page-loader.ts
+++ b/app/app/page-loader.ts
@@ -1,0 +1,110 @@
+import { type Route } from "./router.js";
+import { METHODS } from "../runtime/method-catalog.js";
+
+type RecordValue = Record<string, unknown>;
+
+interface RuntimeBridgeLike {
+    request<T extends RecordValue = RecordValue>(
+        method: string,
+        params?: Record<string, unknown>,
+        timeoutMs?: number,
+    ): Promise<T>;
+}
+
+interface RouteDataLoaderContext {
+    bridge: RuntimeBridgeLike;
+    route: Route;
+}
+
+export interface RouteDataResult {
+    bootstrapState?: RecordValue;
+    identifier?: RecordValue;
+    identifiers?: RecordValue[];
+    remote?: RecordValue;
+    remotes?: RecordValue[];
+    settings?: RecordValue;
+    watcherError?: string;
+    watchers?: RecordValue[];
+    witnessError?: string;
+    witnesses?: RecordValue[];
+}
+
+export async function loadRouteData({ bridge, route }: RouteDataLoaderContext): Promise<RouteDataResult> {
+    if (route.name === "identifiers") {
+        const vaultId = route.params.vaultId ?? "";
+        return bridge.request<{ identifiers: RecordValue[] }>(METHODS.identifiersList, { vaultId });
+    }
+
+    if (route.name === "identifier-detail") {
+        return bridge.request<{ identifier: RecordValue }>(METHODS.identifiersGet, {
+            vaultId: route.params.vaultId,
+            aid: route.params.aid,
+        });
+    }
+
+    if (route.name === "remotes") {
+        const vaultId = route.params.vaultId ?? "";
+        return bridge.request<{ remotes: RecordValue[] }>(METHODS.remotesList, {
+            vaultId,
+        });
+    }
+
+    if (route.name === "remote-detail") {
+        return bridge.request<{ remote: RecordValue }>(METHODS.remotesGet, {
+            vaultId: route.params.vaultId,
+            aid: route.params.aid,
+        });
+    }
+
+    if (route.name === "settings") {
+        return bridge.request<{ settings: RecordValue }>(METHODS.settingsGet, {
+            vaultId: route.params.vaultId,
+        });
+    }
+
+    if (route.name === "kf-witnesses") {
+        const vaultId = route.params.vaultId ?? "";
+        const bootstrapState = await bridge.request<RecordValue>(METHODS.kfBootstrapGet, { vaultId });
+        let witnesses: RecordValue[] = [];
+        let witnessError = "";
+        if ((bootstrapState.account as RecordValue | undefined)?.status === "onboarded") {
+            try {
+                ({ witnesses } = await bridge.request<{ witnesses: RecordValue[] }>(
+                    METHODS.kfAccountWitnessesList,
+                    { vaultId },
+                ));
+            } catch (error) {
+                witnessError = error instanceof Error ? error.message : "Failed to load hosted witness rows.";
+            }
+        }
+        return {
+            bootstrapState,
+            witnesses,
+            witnessError,
+        };
+    }
+
+    if (route.name === "kf-watchers") {
+        const vaultId = route.params.vaultId ?? "";
+        const bootstrapState = await bridge.request<RecordValue>(METHODS.kfBootstrapGet, { vaultId });
+        let watchers: RecordValue[] = [];
+        let watcherError = "";
+        if ((bootstrapState.account as RecordValue | undefined)?.status === "onboarded") {
+            try {
+                ({ watchers } = await bridge.request<{ watchers: RecordValue[] }>(
+                    METHODS.kfAccountWatchersList,
+                    { vaultId },
+                ));
+            } catch (error) {
+                watcherError = error instanceof Error ? error.message : "Failed to load hosted watcher rows.";
+            }
+        }
+        return {
+            bootstrapState,
+            watchers,
+            watcherError,
+        };
+    }
+
+    return {};
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,7 @@
     "app/runtime/method-catalog.ts",
     "app/app/router.ts",
     "app/app/session.ts",
+    "app/app/page-loader.ts",
     "app/runtime/logger.ts",
     "app/runtime/types/**/*.d.ts",
     "app/runtime/bridge.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "app/runtime/method-catalog.ts",
     "app/app/router.ts",
     "app/app/session.ts",
+    "app/app/page-loader.ts",
     "app/runtime/logger.ts",
     "app/runtime/types/**/*.d.ts",
     "app/runtime/bridge.ts",


### PR DESCRIPTION
## Summary
Extract FortWeb route data loading into a typed helper without widening the rendering slice.

## Included
- move route data fetching from `main.js` into `page-loader.ts`
- keep page rendering in `main.js` so the slice stays isolated from untyped UI modules
- add the emitted browser runtime file on the existing no-bundler path

## Validation
- `npm run typecheck`
- `npm run build:runtime`
- `npm run test:e2e`
