### PR TITLE
refactor(ui): migrate FortWeb button and badge primitives to TypeScript

### DIFF
--- a/app/ui/primitives/badge.ts
+++ b/app/ui/primitives/badge.ts
@@ -1,5 +1,14 @@
 import { escapeHtml } from "../../shared/dom.js";
-export function badgeHtml(props) {
+
+type BadgeTone = "neutral" | "success" | "warning" | "danger" | "info";
+
+interface BadgeProps {
+    label: string;
+    tone?: BadgeTone;
+    className?: string;
+}
+
+export function badgeHtml(props: BadgeProps): string {
     const { label, tone = "neutral", className = "" } = props;
     const classes = ["badge", `badge--${tone}`, className].filter(Boolean).join(" ");
     return `<span class="${classes}">${escapeHtml(label)}</span>`;

--- a/app/ui/primitives/button.js
+++ b/app/ui/primitives/button.js
@@ -1,45 +1,16 @@
 import { escapeHtml } from "../../shared/dom.js";
-
-/**
- * @typedef {Object} ButtonProps
- * @property {string} label
- * @property {"primary"|"secondary"|"ghost"|"danger"} [tone="primary"]
- * @property {"button"|"submit"|"reset"} [type="button"]
- * @property {boolean} [disabled=false]
- * @property {string} [icon] - HTML string for a leading icon
- * @property {string} [dataAction] - value for data-action attribute
- * @property {string} [className] - additional CSS classes
- */
-
-/**
- * Render a button element as an HTML string.
- *
- * @param {ButtonProps} props
- * @returns {string}
- */
 export function buttonHtml(props) {
-    const {
-        label,
-        tone = "primary",
-        type = "button",
-        disabled = false,
-        icon = "",
-        dataAction = "",
-        className = "",
-    } = props;
-
+    const { label, tone = "primary", type = "button", disabled = false, icon = "", dataAction = "", className = "", } = props;
     const classes = [
         "button",
         `button--${tone}`,
         className,
     ].filter(Boolean).join(" ");
-
     const attrs = [
         `type="${type}"`,
         `class="${classes}"`,
         disabled ? "disabled" : "",
         dataAction ? `data-action="${escapeHtml(dataAction)}"` : "",
     ].filter(Boolean).join(" ");
-
     return `<button ${attrs}>${icon}<span>${escapeHtml(label)}</span></button>`;
 }

--- a/app/ui/primitives/button.ts
+++ b/app/ui/primitives/button.ts
@@ -1,0 +1,41 @@
+import { escapeHtml } from "../../shared/dom.js";
+
+type ButtonTone = "primary" | "secondary" | "ghost" | "danger";
+type ButtonType = "button" | "submit" | "reset";
+
+interface ButtonProps {
+    label: string;
+    tone?: ButtonTone;
+    type?: ButtonType;
+    disabled?: boolean;
+    icon?: string;
+    dataAction?: string;
+    className?: string;
+}
+
+export function buttonHtml(props: ButtonProps): string {
+    const {
+        label,
+        tone = "primary",
+        type = "button",
+        disabled = false,
+        icon = "",
+        dataAction = "",
+        className = "",
+    } = props;
+
+    const classes = [
+        "button",
+        `button--${tone}`,
+        className,
+    ].filter(Boolean).join(" ");
+
+    const attrs = [
+        `type="${type}"`,
+        `class="${classes}"`,
+        disabled ? "disabled" : "",
+        dataAction ? `data-action="${escapeHtml(dataAction)}"` : "",
+    ].filter(Boolean).join(" ");
+
+    return `<button ${attrs}>${icon}<span>${escapeHtml(label)}</span></button>`;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -28,6 +28,8 @@
     "app/features/settings/settings-page.ts",
     "app/features/vaults/unlock-page.ts",
     "app/features/vaults/vault-picker-page.ts",
+    "app/ui/primitives/badge.ts",
+    "app/ui/primitives/button.ts",
     "app/ui/primitives/field-text.ts",
     "app/ui/primitives/chip.ts",
     "app/runtime/global-handlers.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,8 @@
     "app/features/settings/settings-page.ts",
     "app/features/vaults/unlock-page.ts",
     "app/features/vaults/vault-picker-page.ts",
+    "app/ui/primitives/badge.ts",
+    "app/ui/primitives/button.ts",
     "app/ui/primitives/field-text.ts",
     "app/ui/primitives/chip.ts",
     "app/runtime/global-handlers.ts",


### PR DESCRIPTION
## Summary
- convert `app/ui/primitives/button` from handwritten JavaScript source to TypeScript
- convert `app/ui/primitives/badge` from handwritten JavaScript source to TypeScript
- include both primitive modules in the FortWeb typecheck and runtime build surfaces

## Validation
- `npm run typecheck`
- `npm run build:runtime`
- `npm run test:e2e -- --reporter=line`

## Stack
- base branch: `fortweb/pr16-ui-field-primitives-ts`
- this PR contains only the button-and-badge primitive migration slice