### PR TITLE
refactor(ui): migrate FortWeb empty state to TypeScript

### DIFF
--- a/app/ui/composites/empty-state.ts
+++ b/app/ui/composites/empty-state.ts
@@ -1,7 +1,26 @@
 import { escapeHtml } from "../../shared/dom.js";
-export function emptyStateHtml(props) {
-    const { title, message = "", iconSrc = "", primaryActionHtml = "", secondaryActionHtml = "", className = "", } = props;
+
+interface EmptyStateProps {
+    title: string;
+    message?: string;
+    iconSrc?: string;
+    primaryActionHtml?: string;
+    secondaryActionHtml?: string;
+    className?: string;
+}
+
+export function emptyStateHtml(props: EmptyStateProps): string {
+    const {
+        title,
+        message = "",
+        iconSrc = "",
+        primaryActionHtml = "",
+        secondaryActionHtml = "",
+        className = "",
+    } = props;
+
     const classes = ["ui-empty-state", className].filter(Boolean).join(" ");
+
     return `
         <div class="${classes}">
             ${iconSrc ? `<img class="ui-empty-state__icon" src="${escapeHtml(iconSrc)}" alt="" width="48" height="48">` : ""}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -28,6 +28,7 @@
     "app/features/settings/settings-page.ts",
     "app/features/vaults/unlock-page.ts",
     "app/features/vaults/vault-picker-page.ts",
+    "app/ui/composites/empty-state.ts",
     "app/ui/primitives/badge.ts",
     "app/ui/primitives/button.ts",
     "app/ui/primitives/field-text.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "app/features/settings/settings-page.ts",
     "app/features/vaults/unlock-page.ts",
     "app/features/vaults/vault-picker-page.ts",
+    "app/ui/composites/empty-state.ts",
     "app/ui/primitives/badge.ts",
     "app/ui/primitives/button.ts",
     "app/ui/primitives/field-text.ts",


### PR DESCRIPTION
## Summary
- convert `app/ui/composites/empty-state` from handwritten JavaScript source to TypeScript
- include the empty-state module in the FortWeb typecheck and runtime build surfaces
- regenerate the emitted browser module for the no-bundler runtime path

## Validation
- `npm run typecheck`
- `npm run build:runtime`
- `npm run test:e2e -- --reporter=line`

## Stack
- base branch: `fortweb/pr17-ui-button-badge-ts`
- this PR contains only the empty-state migration slice