### PR TITLE
chore(runtime): guard against stale generated JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "scripts": {
     "build:runtime": "tsc --project tsconfig.build.json",
+    "check:runtime-js": "node tools/check-runtime-js.mjs",
+    "test:runtime-js-check": "node --test tools/check-runtime-js.test.mjs",
     "typecheck": "tsc --project tsconfig.json",
     "pretest:e2e": "npm run build:runtime",
     "test:e2e": "playwright test",

--- a/tools/check-runtime-js.mjs
+++ b/tools/check-runtime-js.mjs
@@ -1,0 +1,163 @@
+import { createHash } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PROJECT_DIR = path.resolve(__dirname, '..');
+
+function isConcreteTypeScriptPath(includePath) {
+    return includePath.endsWith('.ts') && !includePath.endsWith('.d.ts') && !includePath.includes('*');
+}
+
+export async function loadRuntimeOutputPaths(projectDir = DEFAULT_PROJECT_DIR) {
+    const tsconfigPath = path.join(projectDir, 'tsconfig.build.json');
+    const tsconfig = JSON.parse(await readFile(tsconfigPath, 'utf8'));
+    const includes = Array.isArray(tsconfig.include) ? tsconfig.include : [];
+
+    return includes
+        .filter(isConcreteTypeScriptPath)
+        .map((includePath) => includePath.replace(/\.ts$/u, '.js'));
+}
+
+async function fileFingerprint(filePath) {
+    try {
+        const buffer = await readFile(filePath);
+        const digest = createHash('sha256').update(buffer).digest('hex');
+        const info = await stat(filePath);
+        return {
+            exists: true,
+            digest,
+            size: info.size,
+        };
+    } catch {
+        return {
+            exists: false,
+            digest: null,
+            size: null,
+        };
+    }
+}
+
+export async function captureSnapshot(projectDir, relativePaths) {
+    const entries = await Promise.all(
+        relativePaths.map(async (relativePath) => {
+            const absolutePath = path.join(projectDir, relativePath);
+            return [relativePath, await fileFingerprint(absolutePath)];
+        }),
+    );
+
+    return new Map(entries);
+}
+
+export function diffSnapshots(beforeSnapshot, afterSnapshot) {
+    const changed = [];
+
+    for (const [relativePath, before] of beforeSnapshot.entries()) {
+        const after = afterSnapshot.get(relativePath);
+        if (!after) {
+            changed.push(relativePath);
+            continue;
+        }
+
+        if (before.exists !== after.exists || before.digest !== after.digest || before.size !== after.size) {
+            changed.push(relativePath);
+        }
+    }
+
+    return changed.sort();
+}
+
+function runCommand(command, args, cwd) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd,
+            stdio: 'inherit',
+        });
+
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+
+            reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code ?? 'unknown'}`));
+        });
+    });
+}
+
+async function readGitStatus(projectDir, relativePaths) {
+    return new Promise((resolve, reject) => {
+        const child = spawn('git', ['status', '--short', '--', ...relativePaths], {
+            cwd: projectDir,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk.toString();
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+        });
+
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve(stdout.trim().split('\n').filter(Boolean));
+                return;
+            }
+
+            reject(new Error(stderr.trim() || `git status failed with exit code ${code ?? 'unknown'}`));
+        });
+    });
+}
+
+export function createFailureMessage(changedOutputs, preExistingDirtyOutputs = []) {
+    const lines = [
+        '[check-runtime-js] stale runtime JavaScript detected.',
+        'TypeScript is the source of truth for FortWeb runtime modules.',
+        'Adjacent .js runtime artifacts changed when the runtime build was re-run.',
+        'Run `npm run build:runtime`, review the emitted .js changes, and include them before staging Fort-ios payloads.',
+        'Do not stage Fort-ios payloads from stale JS.',
+        '',
+        'Changed runtime artifacts:',
+        ...changedOutputs.map((outputPath) => `- ${outputPath}`),
+    ];
+
+    if (preExistingDirtyOutputs.length > 0) {
+        lines.push('', 'Pre-existing dirty runtime artifacts before the check:', ...preExistingDirtyOutputs.map((entry) => `- ${entry}`));
+    }
+
+    return lines.join('\n');
+}
+
+export async function main(projectDir = DEFAULT_PROJECT_DIR) {
+    const runtimeOutputs = await loadRuntimeOutputPaths(projectDir);
+    const beforeSnapshot = await captureSnapshot(projectDir, runtimeOutputs);
+    const preExistingDirtyOutputs = await readGitStatus(projectDir, runtimeOutputs);
+
+    await runCommand('npm', ['run', 'build:runtime'], projectDir);
+
+    const afterSnapshot = await captureSnapshot(projectDir, runtimeOutputs);
+    const changedOutputs = diffSnapshots(beforeSnapshot, afterSnapshot);
+
+    if (changedOutputs.length > 0) {
+        throw new Error(createFailureMessage(changedOutputs, preExistingDirtyOutputs));
+    }
+
+    process.stdout.write('[check-runtime-js] runtime JavaScript artifacts are in sync with TypeScript.\n');
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (entrypointPath === fileURLToPath(import.meta.url)) {
+    main().catch((error) => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/tools/check-runtime-js.test.mjs
+++ b/tools/check-runtime-js.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    createFailureMessage,
+    diffSnapshots,
+    loadRuntimeOutputPaths,
+} from './check-runtime-js.mjs';
+
+test('loadRuntimeOutputPaths maps emitted runtime JavaScript files', async () => {
+    const outputs = await loadRuntimeOutputPaths();
+
+    assert(outputs.includes('app/app/main.js'));
+    assert(outputs.includes('app/runtime/bridge.js'));
+    assert(outputs.includes('app/runtime/messages.js'));
+    assert(!outputs.some((outputPath) => outputPath.endsWith('.d.js')));
+    assert(!outputs.some((outputPath) => outputPath.includes('vendor/')));
+});
+
+test('diffSnapshots reports changed runtime outputs', () => {
+    const before = new Map([
+        ['app/app/main.js', { exists: true, digest: 'old', size: 10 }],
+        ['app/runtime/bridge.js', { exists: true, digest: 'same', size: 20 }],
+    ]);
+    const after = new Map([
+        ['app/app/main.js', { exists: true, digest: 'new', size: 11 }],
+        ['app/runtime/bridge.js', { exists: true, digest: 'same', size: 20 }],
+    ]);
+
+    assert.deepEqual(diffSnapshots(before, after), ['app/app/main.js']);
+});
+
+test('createFailureMessage explains stale JS guardrail', () => {
+    const message = createFailureMessage(['app/app/main.js'], ['M  app/app/main.js']);
+
+    assert.match(message, /TypeScript is the source of truth/i);
+    assert.match(message, /Run `npm run build:runtime`/);
+    assert.match(message, /Do not stage Fort-ios payloads from stale JS/i);
+    assert.match(message, /app\/app\/main\.js/);
+});


### PR DESCRIPTION
## Summary

Adds a runtime-JS freshness check so TypeScript remains the source of truth for FortWeb runtime modules.

The check:
- runs the runtime TypeScript build
- verifies adjacent emitted JS artifacts stay in sync
- excludes vendor JS by deriving outputs from 
- fails with an actionable message before stale JS can be staged into mobile payloads

## Validation

- 
> test:runtime-js-check
> node --test tools/check-runtime-js.test.mjs

[32m✔ loadRuntimeOutputPaths maps emitted runtime JavaScript files [90m(2.592417ms)[39m[39m
[32m✔ diffSnapshots reports changed runtime outputs [90m(0.589958ms)[39m[39m
[32m✔ createFailureMessage explains stale JS guardrail [90m(0.120084ms)[39m[39m
[34mℹ tests 3[39m
[34mℹ suites 0[39m
[34mℹ pass 3[39m
[34mℹ fail 0[39m
[34mℹ cancelled 0[39m
[34mℹ skipped 0[39m
[34mℹ todo 0[39m
[34mℹ duration_ms 73.499083[39m
- 
> typecheck
> tsc --project tsconfig.json
- 
> build:runtime
> tsc --project tsconfig.build.json
- 
> check:runtime-js
> node tools/check-runtime-js.mjs


> build:runtime
> tsc --project tsconfig.build.json

[check-runtime-js] runtime JavaScript artifacts are in sync with TypeScript.
- 

## Notes

This PR does not change create-vault runtime behavior. It is a source-of-truth guardrail only.
